### PR TITLE
feat: Add navbar login

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,7 +12,28 @@ export default function Navbar() {
   const navigate = useNavigate()
   function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    alert("Login not implemented yet!")
+    console.log("Logging in...")
+    fetch("https://auth.dearborncodingclub.com/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      referrerPolicy: 'no-referrer',
+      body: JSON.stringify({ username, password }),
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        if (data.token) {
+          alert("Login successful")
+          console.log("Login successful")
+        } else {
+          alert("Login failed")
+          console.log("Login failed")
+        }
+      })
+      .catch((error) => {
+        console.error("Error:", error)
+      })
   }
   const [username, setUsername] = useState("")
   const [password, setPassword] = useState("")

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -10,6 +10,18 @@ export default function Navbar() {
   const [navRevealedState, setNavRevealedState] = useState(false)
   const { theme } = useTheme()
   const navigate = useNavigate()
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    alert("Login not implemented yet!")
+  }
+  const [username, setUsername] = useState("")
+  const [password, setPassword] = useState("")
+  function handleUsernameChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setUsername(event.target.value)
+  }
+  function handlePasswordChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setPassword(event.target.value)
+  }
 
   return (
     <>
@@ -29,6 +41,27 @@ export default function Navbar() {
         />
 
         <div style={{ display: "flex", alignItems: "center", gap: 15 }}>
+          <form onSubmit={handleSubmit}>
+            <div>
+              <label htmlFor="username">Username:</label>
+              <input
+                type="text"
+                id="username"
+                value={username}
+                onChange={handleUsernameChange}
+              />
+            </div>
+            <div>
+              <label htmlFor="password">Password:</label>
+              <input
+                type="password"
+                id="password"
+                value={password}
+                onChange={handlePasswordChange}
+              />
+            </div>
+            <button type="submit">Login</button>
+          </form>
           <ThemeToggle />
           <button
             title="Menu"


### PR DESCRIPTION
## Summary
- Adds a very base login experience that successfully integrates the front end with the auth server. The auth server now returns an JWT access token, `token`, and a refresh token, `refresh_token`.
- The current username password combination that works is: `username`: `potato`, `password`: `testpassword`.

## Context
We really would like to gate some of our endpoints behind a login experience. This can be done with a simple login flow and a stored token.

## Screenshots
<img width="1495" alt="Screenshot 2024-12-21 at 10 37 28 PM" src="https://github.com/user-attachments/assets/244fac93-88d3-4f0b-949f-dd4708835255" />

