### PR TITLE
Fix: Navbar-menu close button is visible for mobile view

### DIFF
--- a/src/css/Navbar.css
+++ b/src/css/Navbar.css
@@ -43,7 +43,7 @@
 .Menu {
   position: fixed;
   z-index: 2;
-  top: 0;
+  top: 100px;
   left: 0;
   right: 0;
   bottom: 0;
@@ -78,6 +78,7 @@
 @media (min-width: 768px) {
   .Menu {
     position: fixed;
+    z-index: 2;
     top: 100px;
     left: auto;
     width: 200px;


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-frontend/issues/89

## Summary
- Navbar-menu close button used to disappear on mobile view. The CSS change fixes this issue.

## Context
- Navbar menu was set to `top: 0px` on mobile view. That is why the navbar would go behind the menu as a result the button would disappear. Now the CSS is set to `top:100px`. So, the menu div starts after the navbar div resulting in visible close button. 
