### PR TITLE
scroll value for smooth transition fixed

### DIFF
--- a/src/hooks/useProjectCarousel.tsx
+++ b/src/hooks/useProjectCarousel.tsx
@@ -61,13 +61,13 @@ const useProjectCarousel = (prop: ProjectCarouselProp = {}) => {
         const leftPosition = listRef.current.getBoundingClientRect().x
         if(rightPosition<center) {
             cardWrapperRef.current.scrollTo({
-                left: cardWrapperRef.current.scrollLeft - ((carouselCardWidth+gap)*projectList.length),
+                left: cardWrapperRef.current.scrollLeft - listRef.current.clientWidth,
                 behavior: "instant"
             })
         }
         if(leftPosition>center) {
             cardWrapperRef.current.scrollTo({
-                left: cardWrapperRef.current.scrollLeft + ((carouselCardWidth+gap)*projectList.length),
+                left: cardWrapperRef.current.scrollLeft + listRef.current.clientWidth,
                 behavior: "instant"
             })
         }


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-frontend/issues/92

## Summary
- The infinite scroll should scroll just the right amount when it reaches end of the list. The calculation was a bit off, and the user could see the scroll transition. Now it is set to correct value to ensure smooth transition.