### PR TITLE
fix: Update PR template ordering

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 Closes <Related issue>
 
+## Context
+<Relevant backstory for understanding the purpose of this PR>
+
 ## Summary
 - <Bulleted list of what the PR does>
-
-## Context
-- <Relevant backstory for understanding the purpose of this PR>
 
 ## Screenshots
 - <If applicable, attach screenshots of the changes.>


### PR DESCRIPTION
## Summary
- Changes the ordering of the PR template so that the `Context` section comes before the `Summary` section.

## Context
- Changes the ordering of the PR template so the `Context` section comes before the `Summary` section.