### PR TITLE
fix: Introduce fallback route to fix 404's on unknown routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,3 @@
 FROM pierrezemb/gostatic
 COPY ./dist/ /srv/http/
+ENV fallback=/src/http/index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM pierrezemb/gostatic
 COPY ./dist/ /srv/http/
-ENV fallback=/src/http/index.html
+ENV fallback=index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM pierrezemb/gostatic
 COPY ./dist/ /srv/http/
-ENV fallback=index.html
+CMD ["-fallback", "index.html"]


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-frontend/issues/54

## Context
When you reload or hit an endpoint that exists in the front end browser router, but not in the goStatic router, the site returns a 404. This PR adds a default route to resolve that (like https://dearborncodingclub.com/profile).

## Summary
- Adds a custom flag to the `goStatic` running process to enable default routing to the base `index.html` file.
