### PR TITLE
Add some requirements for the password on registration

### DIFF
--- a/src/css/Register.css
+++ b/src/css/Register.css
@@ -4,6 +4,7 @@
     align-items: center;
     justify-content: center;
     width: 100%;
+    padding-top: 30px;
     height: 400px;
 }
 
@@ -37,6 +38,29 @@ input[type=submit] {
    border-color: var(--text-color);
    cursor: pointer;
 }
+
+/* General styling for the requirements list */
+.password-requirements {
+    color: #ffffff; /* White text for dark background */
+    font-size: 14px;
+    margin-top: 20px;
+}
+
+.password-requirements ul {
+    list-style-type: disc;
+    padding-left: 20px;
+}
+
+/* Styling for valid items */
+.password-requirements .valid {
+    color: #00ff00; /* Green color for valid items */
+}
+
+/* Styling for invalid items */
+.password-requirements .invalid {
+    color: #ff0000; /* Red color for invalid items */
+}
+
 
 .errorMessage {
     color: red;

--- a/src/css/Register.css
+++ b/src/css/Register.css
@@ -53,15 +53,15 @@ input[type=submit] {
 
 /* Styling for valid items */
 .password-requirements .valid {
-    color: #00ff00; /* Green color for valid items */
+    color: var(--green-color); /* Green color for valid items */
 }
 
 /* Styling for invalid items */
 .password-requirements .invalid {
-    color: #ff0000; /* Red color for invalid items */
+    color: var(--red-color); /* Red color for invalid items */
 }
 
 
 .errorMessage {
-    color: red;
+    color: var(--red-color);
 }

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -6,6 +6,8 @@
   --link-color: #1a73e8;
   --spinner-color: #333;
   --spinner-color1: #f5c24f;
+  --green-color: #4caf50;
+  --red-color: #e57373;
 }
 
 [data-theme="dark"] {
@@ -16,6 +18,8 @@
   --link-color: #4da3ff;
   --spinner-color: #f5c24f;
   --spinner-color1: #333;
+  --green-color: #4caf50;
+  --red-color: #e57373;
 }
 
 body {

--- a/src/hooks/useRegisterForm.tsx
+++ b/src/hooks/useRegisterForm.tsx
@@ -1,53 +1,82 @@
 import { useState } from "react"
 import { toastType, useToastProvider } from "../providers/ToastProvider"
 
-
 const useRegisterForm = () => {
+    const AUTH_SERVER_URL = import.meta.env.VITE_AUTH_SERVER_URL;
+    const { pushToast } = useToastProvider();
 
-    const AUTH_SERVER_URL = import.meta.env.VITE_AUTH_SERVER_URL
+    const [errorMessage, setErrorMessage] = useState("");
+    const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
 
-    const { pushToast } = useToastProvider()
-    
-    const [errorMessage, setErrorMessage] = useState("")
-    
+    const validatePassword = (password: string) => {
+        const minLength = 8;
+        const hasUppercase = /[A-Z]/.test(password);
+        const hasLowercase = /[a-z]/.test(password);
+        const hasNumber = /\d/.test(password);
+        const hasSpecialChar = /[!@#$%^&*(),.?":{}|<>]/.test(password);
+
+        return (
+            password.length >= minLength &&
+            hasUppercase &&
+            hasLowercase &&
+            hasNumber &&
+            hasSpecialChar
+        );
+    };
+
     const registerOnSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault()
-        const username = (e.currentTarget.elements.namedItem('username') as HTMLInputElement).value
-        const password = (e.currentTarget.elements.namedItem('password') as HTMLInputElement).value
-        const confirmPassword = (e.currentTarget.elements.namedItem('confirm-password') as HTMLInputElement).value
+        e.preventDefault();
+        const username = (e.currentTarget.elements.namedItem('username') as HTMLInputElement).value;
+        const email = (e.currentTarget.elements.namedItem('email') as HTMLInputElement).value;
 
-        if(password !== confirmPassword) {
-            setErrorMessage("Passwords do not match!")
+        if (!validatePassword(password)) {
+            setErrorMessage("Password does not meet requirements!");
             setTimeout(() => {
                 setErrorMessage('');
             }, 3000);
             return;
         }
-        fetch(AUTH_SERVER_URL + "/register", {
-            method: "POST",
-            headers: {"Content-Type": "application/json"},
-            body: JSON.stringify({username: username, password: password})
-        })
-        .then(res => {
-            if(res.status !== 200) {
-                throw new Error();
-            }
-            return res.json()
-        })
-        .then(() => {
-            pushToast("Registration Successful!", toastType.SUCCESS)
-        })
-        .catch(() => {
-            setErrorMessage("Failed to create an account!")
+
+        if (password !== confirmPassword) {
+            setErrorMessage("Passwords do not match!");
             setTimeout(() => {
                 setErrorMessage('');
             }, 3000);
-        })
-    }
-    
-    return {errorMessage, registerOnSubmit}
-    
-}
+            return;
+        }
 
+        fetch(AUTH_SERVER_URL + "/register", {
+            method: "POST",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({username, email, password}),
+        })
+            .then(res => {
+                if(res.status !== 200) {
+                    throw new Error();
+                }
+                return res.json();
+            })
+            .then(() => {
+                pushToast("Registration Successful!", toastType.SUCCESS);
+            })
+            .catch(() => {
+                setErrorMessage("Failed to create an account!");
+                setTimeout(() => {
+                    setErrorMessage('');
+                }, 3000);
+            });
+    };
+
+    return {
+        errorMessage,
+        registerOnSubmit,
+        password,
+        setPassword,
+        confirmPassword,
+        setConfirmPassword,
+        validatePassword
+    };
+};
 
 export default useRegisterForm;

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -3,20 +3,51 @@ import "../css/Register.css"
 import useRegisterForm from "../hooks/useRegisterForm"
 
 const Register: React.FC = () => {
+    const {
+        errorMessage,
+        registerOnSubmit,
+        password,
+        setPassword,
+        confirmPassword,
+        setConfirmPassword
+    } = useRegisterForm();
 
-    const { errorMessage, registerOnSubmit } = useRegisterForm()
-
-    return(
+    return (
         <div className="Register">
             <form className="register-form-wrapper" onSubmit={registerOnSubmit}>
-                <input className="" type="text" name="username" placeholder="Username"/>
-                <input className="" type="password" name="password" placeholder="Password"/>
-                <input className="" type="password" name="confirm-password" placeholder="Confirm Password"/>
+                <input className="" type="text" name="username" placeholder="username"/>
+                <input className="" type="email" name="email" placeholder="email"/>
+                <input
+                    className=""
+                    type="password"
+                    name="password"
+                    placeholder="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+                <input
+                    className=""
+                    type="password"
+                    name="confirm-password"
+                    placeholder="confirm password"
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                />
                 <input className="" value="Register" type="submit"/>
                 <label className="errorMessage">{errorMessage}</label>
             </form>
+            <div className="password-requirements">
+                <h4>Password must contain:</h4>
+                <ul>
+                    <li className={password.length >= 8 ? "valid" : "invalid"}>At least 8 characters</li>
+                    <li className={/[A-Z]/.test(password) ? "valid" : "invalid"}>At least one uppercase letter</li>
+                    <li className={/[a-z]/.test(password) ? "valid" : "invalid"}>At least one lowercase letter</li>
+                    <li className={/\d/.test(password) ? "valid" : "invalid"}>At least one number</li>
+                    <li className={/[!@#$%^&*(),.?":{}|<>]/.test(password) ? "valid" : "invalid"}>At least one special character</li>
+                </ul>
+            </div>
         </div>
-    )
-}
+    );
+};
 
 export default Register

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -47,7 +47,7 @@ const Register: React.FC = () => {
                 </ul>
             </div>
         </div>
-    );
-};
+    )
+}
 
 export default Register


### PR DESCRIPTION
**Closes #97**

## Context
This PR addresses the need to validate user passwords during registration. The current implementation lacks real-time feedback for password requirements, which can lead to user frustration and errors during account creation.
I also add email as a field in the registration form

## Summary
- Added email as a parameter in registration
- Added password validation logic to ensure passwords meet the following criteria:
  - At least 8 characters
  - At least one uppercase letter
  - At least one lowercase letter
  - At least one number
  - At least one special character
- Updated the UI to dynamically display validation states for password requirements.
- Styled valid and invalid states for better user experience.

## Screenshots
![Screenshot 2025-02-27 at 12 41 28 PM](https://github.com/user-attachments/assets/182e3e18-88ed-4f2d-b244-291ce1c1142f)
