### PR TITLE
fix: Conditionally call `validate-token`

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,8 +1,19 @@
 import "../css/Profile.css"
 import DummyProfilePicture from "../assets/dummy-profile.png"
 import CircularProgressBar from "../components/CircularProgressBar"
+import React, { useEffect } from "react"
 
 const Profile: React.FC = () => {
+
+    useEffect(() => {
+        const fetchProfileData = async () => {
+            const response = await fetch("https://api.dearborncodingclub.com/profile")
+            const data = await response.json()
+            console.log(data)
+        };
+        fetchProfileData();
+    }, []);
+
     return (
         <div className="Profile">
 

--- a/src/providers/AuthServiceProvider.tsx
+++ b/src/providers/AuthServiceProvider.tsx
@@ -62,23 +62,28 @@ export const AuthServiceProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
     useEffect(() => {
         startLoading()
-        fetch(AUTH_SERVER_URL + "/validate-token", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": `bearer ${token}`
-        }
-        })
-        .then(res => {
-            if(res.status !== 200) {
-                throw new Error()
+        if(token == null) {
+            fetch(AUTH_SERVER_URL + "/validate-token", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `bearer ${token}`
             }
-            stopLoading()
-        })
-        .catch(() => {
+            })
+            .then(res => {
+                if(res.status !== 200) {
+                    throw new Error()
+                }
+                stopLoading()
+            })
+            .catch(() => {
+                stopLoading()
+                logout()
+            })
+        } else {
             stopLoading()
             logout()
-        })
+        }
     },[])
 
     return (


### PR DESCRIPTION
## Context
- Conditionally call `/validate-token`, only if `token` exists - this prevents `401 Unauthorized` calls on the `auth` server.
