### PR TITLE
fix: Use capital `Bearer` for Authorization header

### DIFF
--- a/src/pages/Notes.tsx
+++ b/src/pages/Notes.tsx
@@ -36,7 +36,7 @@ const Notes: React.FC = () => {
         body: JSON.stringify({title: title, content: notes}),
         headers: {
           "Content-type": "application/json; charset=UTF-8",
-          "Authorization": `bearer ${token || ""}`,
+          "Authorization": `Bearer ${token || ""}`,
         }
       }
     )
@@ -61,7 +61,7 @@ const Notes: React.FC = () => {
             method: "GET",
             headers: {
               "Content-type": "application/json; charset=UTF-8",
-              "Authorization": `bearer ${token || ""}`,
+              "Authorization": `Bearer ${token || ""}`,
             },
           }
         )

--- a/src/providers/AuthServiceProvider.tsx
+++ b/src/providers/AuthServiceProvider.tsx
@@ -67,7 +67,7 @@ export const AuthServiceProvider: React.FC<{ children: React.ReactNode }> = ({ c
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                "Authorization": `bearer ${token}`
+                "Authorization": `Bearer ${token}`
             }
             })
             .then(res => {


### PR DESCRIPTION
## Context
- Introduces `Bearer` token nomenclature instead of the misspelled `bearer` that existed before.
